### PR TITLE
Reduce the default timer period of 50ms to 4ms 

### DIFF
--- a/src/main/thingml/posix.thingml
+++ b/src/main/thingml/posix.thingml
@@ -43,6 +43,7 @@ configuration test
 	instance game : BreakoutGamePosix
 	instance disp : HeadlessDisplay
 	instance timer : TimerPosix
+		set timer.SOFT_TIMER_PERIOD = 4
 
 	connector game.clock => timer.timer
 	connector game.display => disp.display


### PR DESCRIPTION
4ms was the default in earlier versions of ThingML